### PR TITLE
Search functionality implemented, integrates RxNorm external API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,8 @@
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -46,11 +42,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>
@@ -61,11 +52,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/kelley/medicationassistant/MedicationassistantApplication.java
+++ b/src/main/java/com/kelley/medicationassistant/MedicationassistantApplication.java
@@ -2,8 +2,12 @@ package com.kelley.medicationassistant;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class MedicationassistantApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/kelley/medicationassistant/config/AppConfig.java
+++ b/src/main/java/com/kelley/medicationassistant/config/AppConfig.java
@@ -1,0 +1,7 @@
+package com.kelley.medicationassistant.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+}

--- a/src/main/java/com/kelley/medicationassistant/controller/MedicationController.java
+++ b/src/main/java/com/kelley/medicationassistant/controller/MedicationController.java
@@ -1,0 +1,30 @@
+package com.kelley.medicationassistant.controller;
+
+import com.kelley.medicationassistant.model.Medication;
+import com.kelley.medicationassistant.service.MedicationService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/medication")
+public class MedicationController {
+
+    private final MedicationService medicationService;
+
+    public MedicationController(MedicationService medicationService) {
+        this.medicationService = medicationService;
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<Page<Medication>> search(@RequestParam String query,
+                                                   Pageable pageable) {
+        Page<Medication> response = medicationService.search(query, pageable);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/kelley/medicationassistant/exception/APIException.java
+++ b/src/main/java/com/kelley/medicationassistant/exception/APIException.java
@@ -1,0 +1,10 @@
+package com.kelley.medicationassistant.exception;
+
+public class APIException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public APIException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/kelley/medicationassistant/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kelley/medicationassistant/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.kelley.medicationassistant.exception;
+
+import com.kelley.medicationassistant.payload.APIResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(APIException.class)
+    public ResponseEntity<APIResponse> handleAPIException(APIException e) {
+        APIResponse apiResponse = new APIResponse(e.getMessage());
+        return new ResponseEntity<>(apiResponse, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/kelley/medicationassistant/feignclient/RxNormClient.java
+++ b/src/main/java/com/kelley/medicationassistant/feignclient/RxNormClient.java
@@ -1,0 +1,13 @@
+package com.kelley.medicationassistant.feignclient;
+
+import com.kelley.medicationassistant.payload.RxNormResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "rxNormClient", url = "https://rxnav.nlm.nih.gov/REST")
+public interface RxNormClient {
+
+    @GetMapping(value = "/drugs.json")
+    RxNormResponse getDrugs(@RequestParam("name") String name);
+}

--- a/src/main/java/com/kelley/medicationassistant/model/Medication.java
+++ b/src/main/java/com/kelley/medicationassistant/model/Medication.java
@@ -1,0 +1,13 @@
+package com.kelley.medicationassistant.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Medication {
+    private String name;
+    private String rxcui;
+}

--- a/src/main/java/com/kelley/medicationassistant/model/MedicationChatOption.java
+++ b/src/main/java/com/kelley/medicationassistant/model/MedicationChatOption.java
@@ -1,0 +1,4 @@
+package com.kelley.medicationassistant.model;
+
+public enum MedicationChatOption {
+}

--- a/src/main/java/com/kelley/medicationassistant/payload/APIResponse.java
+++ b/src/main/java/com/kelley/medicationassistant/payload/APIResponse.java
@@ -1,0 +1,12 @@
+package com.kelley.medicationassistant.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class APIResponse {
+    private String message;
+}

--- a/src/main/java/com/kelley/medicationassistant/payload/RxNormResponse.java
+++ b/src/main/java/com/kelley/medicationassistant/payload/RxNormResponse.java
@@ -1,0 +1,30 @@
+package com.kelley.medicationassistant.payload;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RxNormResponse {
+    private DrugGroup drugGroup;
+
+    @Data
+    public static class DrugGroup {
+        private List<ConceptGroup> conceptGroup;
+    }
+
+    @Data
+    public static class ConceptGroup {
+        private List<ConceptProperty> conceptProperties;
+    }
+
+    @Data
+    public static class ConceptProperty {
+        private String rxcui;
+        private String name;
+    }
+}

--- a/src/main/java/com/kelley/medicationassistant/service/MedicationService.java
+++ b/src/main/java/com/kelley/medicationassistant/service/MedicationService.java
@@ -1,0 +1,9 @@
+package com.kelley.medicationassistant.service;
+
+import com.kelley.medicationassistant.model.Medication;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MedicationService {
+    Page<Medication> search(String query, Pageable pageable);
+}

--- a/src/main/java/com/kelley/medicationassistant/service/MedicationServiceImpl.java
+++ b/src/main/java/com/kelley/medicationassistant/service/MedicationServiceImpl.java
@@ -1,0 +1,84 @@
+package com.kelley.medicationassistant.service;
+
+import com.kelley.medicationassistant.exception.APIException;
+import com.kelley.medicationassistant.feignclient.RxNormClient;
+import com.kelley.medicationassistant.model.Medication;
+import com.kelley.medicationassistant.payload.RxNormResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class MedicationServiceImpl implements MedicationService {
+
+    private final RxNormClient rxNormClient;
+
+    public MedicationServiceImpl(RxNormClient rxNormClient) {
+        this.rxNormClient = rxNormClient;
+    }
+
+    @Override
+    public Page<Medication> search(String query, Pageable pageable) {
+        // Call RxNorm API using OpenFeign
+        RxNormResponse response = rxNormClient.getDrugs(query);
+
+        /*
+        Initialize list to contain all returned medications.
+        RxNorm API does not allow for pagination, so custom pagination
+        will be implemented below.
+         */
+        List<Medication> allMedications = new ArrayList<>();
+
+        // Extract desired data from the nested RxNorm API Response
+        if (response != null && response.getDrugGroup() != null) {
+            List<RxNormResponse.ConceptGroup> conceptGroups = response.getDrugGroup().getConceptGroup();
+
+            if (conceptGroups == null)
+                    throw new APIException("Search returned no results. Please try a different query.");
+
+            for (RxNormResponse.ConceptGroup group: conceptGroups) {
+                if (group.getConceptProperties() != null) {
+                    for (RxNormResponse.ConceptProperty prop : group.getConceptProperties()) {
+                        allMedications.add(new Medication(
+                                prop.getName(),
+                                prop.getRxcui()
+                        ));
+                    }
+                }
+            }
+
+            // Total number of medications fetched from RxNorm
+            int total = allMedications.size();
+
+
+            /*
+             Calculate start and end index based on page and size
+             */
+
+            // page 1, size 10 => offset 10
+            int start = (int) pageable.getOffset();
+
+            int end = Math.min(start + (pageable.getPageSize()), total);
+
+            // If requested start point is greater than total medication count, return empty page
+            if (start > end) {
+                return new PageImpl<>(Collections.emptyList(), pageable, total);
+            }
+
+            // Construct a sublist of items for the requested page
+            List<Medication> medications = allMedications.subList(start, end);
+
+            return new PageImpl<>(medications, pageable, total);
+
+        } else {
+            throw new APIException("Search returned no results. Please try a different query.");
+        }
+
+
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=medicationassistant
+
+
+


### PR DESCRIPTION
- 'search' endpoint allows users to search for a list of specific medications matching a search term
- OpenFeign client interface handles calls to RxNorm external API to gather lists of medications
- search controller endpoint allows for pagination, which has been implemented within the service layer as the RxNorm API itself does not permit pagination