### PR TITLE
Added get related medication functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,9 @@ I created a mock test for the getInformation() method to show the method works a
 
 ![medassistant4](https://github.com/user-attachments/assets/c9c3a5ee-60bd-4b4e-ae2c-c8c1ba190c85)
 
+All medications from the 'search' endpoint will return an rxcui, which is a unique ID for identfying
+medications within the RxNorm API. Another endpoint has been recently added that will find related medications
+given an rxcui. Here is an example of how to call this endpoint with an rxcui of 9801:
+
+
+/api/v1/medication/related/9801

--- a/src/main/java/com/kelley/medicationassistant/controller/MedicationController.java
+++ b/src/main/java/com/kelley/medicationassistant/controller/MedicationController.java
@@ -4,6 +4,7 @@ import com.kelley.medicationassistant.model.Medication;
 import com.kelley.medicationassistant.payload.PromptRequest;
 import com.kelley.medicationassistant.payload.PromptResponse;
 import com.kelley.medicationassistant.service.MedicationService;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -35,6 +36,13 @@ public class MedicationController {
     public ResponseEntity<Page<Medication>> search(@RequestParam String query,
                                                    Pageable pageable) {
         Page<Medication> response = medicationService.search(query, pageable);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/related/{rxcui}")
+    public ResponseEntity<Page<Medication>> getRelated(@PathVariable String rxcui,
+                                                       Pageable pageable) {
+        Page<Medication> response = medicationService.getRelated(rxcui, pageable);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/kelley/medicationassistant/feignclient/RxNormClient.java
+++ b/src/main/java/com/kelley/medicationassistant/feignclient/RxNormClient.java
@@ -1,8 +1,10 @@
 package com.kelley.medicationassistant.feignclient;
 
-import com.kelley.medicationassistant.payload.RxNormResponse;
+import com.kelley.medicationassistant.payload.RxNormGetDrugsResponse;
+import com.kelley.medicationassistant.payload.RxNormGetRelatedDrugsResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
@@ -12,5 +14,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface RxNormClient {
 
     @GetMapping(value = "/drugs.json")
-    RxNormResponse getDrugs(@RequestParam("name") String name);
+    RxNormGetDrugsResponse getDrugs(@RequestParam("name") String name);
+
+    @GetMapping(value = "/rxcui/{rxcui}/allrelated.json")
+    RxNormGetRelatedDrugsResponse getRelatedDrugs(@PathVariable String rxcui);
 }

--- a/src/main/java/com/kelley/medicationassistant/payload/RxNormGetDrugsResponse.java
+++ b/src/main/java/com/kelley/medicationassistant/payload/RxNormGetDrugsResponse.java
@@ -1,5 +1,6 @@
 package com.kelley.medicationassistant.payload;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,14 +8,16 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 
 /**
- * Follows expected formatting for responses from RxNorm API.
+ * Follows expected formatting for 'getDrugs' response from RxNorm API.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class RxNormResponse {
+public class RxNormGetDrugsResponse {
     private DrugGroup drugGroup;
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
@@ -22,6 +25,7 @@ public class RxNormResponse {
         private List<ConceptGroup> conceptGroup;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
@@ -29,6 +33,7 @@ public class RxNormResponse {
         private List<ConceptProperty> conceptProperties;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     @Data
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/com/kelley/medicationassistant/payload/RxNormGetRelatedDrugsResponse.java
+++ b/src/main/java/com/kelley/medicationassistant/payload/RxNormGetRelatedDrugsResponse.java
@@ -1,0 +1,53 @@
+package com.kelley.medicationassistant.payload;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Follows expected format for 'getAllRelatedInfo' response from RxNorm API
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RxNormGetRelatedDrugsResponse {
+    private AllRelatedGroup allRelatedGroup;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AllRelatedGroup {
+        private String rxcui;
+        private List<ConceptGroup> conceptGroup;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ConceptGroup {
+        private String tty;
+        private List<ConceptProperty> conceptProperties;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ConceptProperty {
+        private String rxcui;
+        private String name;
+        private String synonym;
+        private String tty;
+        private String language;
+        private String suppress;
+        private String umlscui;
+    }
+
+
+}

--- a/src/main/java/com/kelley/medicationassistant/service/MedicationService.java
+++ b/src/main/java/com/kelley/medicationassistant/service/MedicationService.java
@@ -27,4 +27,14 @@ public interface MedicationService {
      * @return {@link PromptResponse} DTO containing message from AI provider
      */
     PromptResponse getInformation(PromptRequest request);
+
+    /**
+     * Given an rxcui of a drug (obtained from 'search' method), this method will return a paginated
+     * list of {@link Medication} objects representing related drugs
+     *
+     * @param rxcui rxcui of the drug from which to find related drugs
+     * @param pageable pagination details
+     * @return Page containing paginated related Medication search results
+     */
+    Page<Medication> getRelated(String rxcui, Pageable pageable);
 }

--- a/src/main/java/com/kelley/medicationassistant/service/MedicationServiceImpl.java
+++ b/src/main/java/com/kelley/medicationassistant/service/MedicationServiceImpl.java
@@ -5,10 +5,6 @@ import com.kelley.medicationassistant.feignclient.OpenAiClient;
 import com.kelley.medicationassistant.feignclient.RxNormClient;
 import com.kelley.medicationassistant.model.Medication;
 import com.kelley.medicationassistant.payload.*;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.messages.Message;
-import org.springframework.ai.chat.messages.UserMessage;
-import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -19,6 +15,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Implementation of MedicationService interface.
+ */
 @Service
 public class MedicationServiceImpl implements MedicationService {
 
@@ -33,10 +32,11 @@ public class MedicationServiceImpl implements MedicationService {
         this.openAiClient = openAiClient;
     }
 
+    //TODO : REFACTOR THIS METHOD TO MATCH THE NEW 'getRelated' METHOD BELOW, WHICH USES STREAMS
     @Override
     public Page<Medication> search(String query, Pageable pageable) {
         // Call RxNorm API using OpenFeign
-        RxNormResponse response = rxNormClient.getDrugs(query);
+        RxNormGetDrugsResponse response = rxNormClient.getDrugs(query);
 
         /*
         Initialize list to contain all returned medications.
@@ -47,14 +47,14 @@ public class MedicationServiceImpl implements MedicationService {
 
         // Extract desired data from the nested RxNorm API Response
         if (response != null && response.getDrugGroup() != null) {
-            List<RxNormResponse.ConceptGroup> conceptGroups = response.getDrugGroup().getConceptGroup();
+            List<RxNormGetDrugsResponse.ConceptGroup> conceptGroups = response.getDrugGroup().getConceptGroup();
 
             if (conceptGroups == null)
                 throw new APIException("Search returned no results. Please try a different query.");
 
-            for (RxNormResponse.ConceptGroup group : conceptGroups) {
+            for (RxNormGetDrugsResponse.ConceptGroup group : conceptGroups) {
                 if (group.getConceptProperties() != null) {
-                    for (RxNormResponse.ConceptProperty prop : group.getConceptProperties()) {
+                    for (RxNormGetDrugsResponse.ConceptProperty prop : group.getConceptProperties()) {
                         allMedications.add(new Medication(
                                 prop.getName(),
                                 prop.getRxcui()
@@ -115,6 +115,53 @@ public class MedicationServiceImpl implements MedicationService {
                 .getContent());
     }
 
+
+    @Override
+    public Page<Medication> getRelated(String rxcui, Pageable pageable) {
+        // Call RxNorm API using OpenFeign to find related Medications given an rxcui
+        RxNormGetRelatedDrugsResponse response = rxNormClient.getRelatedDrugs(rxcui);
+
+        // If response is null or empty, throw API Exception
+        if (response == null || response.getAllRelatedGroup() == null)
+            throw new APIException("Search returned no results");
+
+        // Get all concept groups
+        List<RxNormGetRelatedDrugsResponse.ConceptGroup> conceptGroupList =
+                response.getAllRelatedGroup().getConceptGroup();
+
+        // Check if concept group list is null before converting to stream to avoid errors
+        if (conceptGroupList == null)
+            throw new APIException("Search returned no results");
+
+        // Extract name and rxcui of all Medications from nested RxNorm API response
+        List<Medication> allMedicationList =
+                conceptGroupList.stream()
+                        .filter(conceptGroup -> conceptGroup.getConceptProperties() != null)
+                        .flatMap(conceptGroup -> conceptGroup.getConceptProperties().stream())
+                        .map(conceptProperty -> new Medication(
+                                conceptProperty.getName(),
+                                conceptProperty.getRxcui()
+                        ))
+                        .toList();
+
+
+        // Calculate and implement pagination details (RxNorm API does not allow pagination)
+
+        int total = allMedicationList.size();
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), total);
+
+        // If requested start point is greater than total medication count, return empty page
+        if (start > end) {
+            return new PageImpl<>(Collections.emptyList(), pageable, end);
+        }
+
+        List<Medication> paginatedMedicationList = allMedicationList.subList(start, end);
+
+        return new PageImpl<>(paginatedMedicationList, pageable, total);
+    }
+
     /**
      * Helper method to construct a prompt for OpenAI given the details provided in the {@link PromptRequest} DTO
      *
@@ -124,4 +171,6 @@ public class MedicationServiceImpl implements MedicationService {
     private String constructPromptFromPromptRequest(PromptRequest request) {
         return request.getMedicationName() + " " + request.getMedicationChatOption().getValue();
     }
+
+
 }

--- a/src/test/java/com/kelley/medicationassistant/service/MedicationServiceTest.java
+++ b/src/test/java/com/kelley/medicationassistant/service/MedicationServiceTest.java
@@ -1,6 +1,8 @@
 package com.kelley.medicationassistant.service;
 
 import com.kelley.medicationassistant.feignclient.OpenAiClient;
+import com.kelley.medicationassistant.feignclient.RxNormClient;
+import com.kelley.medicationassistant.model.Medication;
 import com.kelley.medicationassistant.model.MedicationChatOption;
 import com.kelley.medicationassistant.payload.*;
 import org.junit.jupiter.api.Test;
@@ -8,6 +10,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -25,24 +30,123 @@ public class MedicationServiceTest {
     @Mock
     private OpenAiClient openAiClient;
 
+    @Mock
+    private RxNormClient rxNormClient;
+
 
     @Test
-    void testGetInformationReturnsMockedResponse() {
-        // Given
+    void testGetInformation_returnsInformation() {
+        /*
+         * Given
+         */
+
+        // Set up a prompt request to pass to 'getInformation' method
         PromptRequest request = new PromptRequest();
         request.setMedicationName("Ibuprofen");
         request.setMedicationChatOption(MedicationChatOption.SIDE_EFFECTS);
 
+        // Define a mock response from OpenAI client
         ChatMessage assistantMessage = new ChatMessage("assistant", "May cause nausea");
         OpenAiResponse mockResponse = new OpenAiResponse(List.of(new OpenAiResponse.Choice(0, assistantMessage)));
 
+        // State that mocked openAI client will always return the mocked response
         when(openAiClient.chat(any(OpenAiRequest.class))).thenReturn(mockResponse);
 
-        // When
+        /*
+         * When
+         */
+
+        // Call the method using defined prompt request
         PromptResponse result = medicationService.getInformation(request);
 
-        // Then
+        /*
+         * Then
+         */
+
+        // Assert the result is not null
         assertNotNull(result);
+        // Assert that the resulting PromptResponseDTO 'message' matches mocked response message
         assertEquals("May cause nausea", result.getMessage());
+    }
+
+    @Test
+    void testSearch_returnsMedications() {
+        /*
+        * Given
+         */
+
+        // Define RxNorm getDrugs mock response
+        RxNormGetDrugsResponse.ConceptProperty conceptProperty =
+                new RxNormGetDrugsResponse.ConceptProperty("R123", "Ibuprofen");
+        RxNormGetDrugsResponse.ConceptGroup conceptGroup =
+                new RxNormGetDrugsResponse.ConceptGroup(List.of(conceptProperty));
+        RxNormGetDrugsResponse.DrugGroup drugGroup =
+                new RxNormGetDrugsResponse.DrugGroup(List.of(conceptGroup));
+        RxNormGetDrugsResponse mockResponse = new RxNormGetDrugsResponse(drugGroup);
+
+        // State that mocked RxNorm Client will always return the mock response
+        when(rxNormClient.getDrugs("Ibuprofen")).thenReturn(mockResponse);
+
+        /*
+        * When
+         */
+
+        // Call the method under test
+        Page<Medication> result =
+                medicationService.search("Ibuprofen", PageRequest.of(0, 10));
+
+        /*
+        * Then
+         */
+
+        // Assertions
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals("Ibuprofen", result.getContent().get(0).getName());
+        assertEquals("R123", result.getContent().get(0).getRxcui());
+    }
+
+    @Test
+    public void testGetRelated_returnsMedications() {
+        /*
+        * Given
+         */
+
+        // Define RxNorm getRelated Mock response
+        RxNormGetRelatedDrugsResponse.ConceptProperty conceptProperty =
+                new RxNormGetRelatedDrugsResponse.ConceptProperty(
+                        "R123",
+                        "Ibuprofen",
+                        "synonym",
+                        "tty",
+                        "EN",
+                        "suppress",
+                        "umlscui"
+                );
+        RxNormGetRelatedDrugsResponse.ConceptGroup conceptGroup =
+                new RxNormGetRelatedDrugsResponse.ConceptGroup("tty", List.of(conceptProperty));
+        RxNormGetRelatedDrugsResponse.AllRelatedGroup allRelatedGroup =
+                new RxNormGetRelatedDrugsResponse.AllRelatedGroup("R123", List.of(conceptGroup));
+        RxNormGetRelatedDrugsResponse mockResponse = new RxNormGetRelatedDrugsResponse(allRelatedGroup);
+
+        // Define 'getRelated' will always return the mocked response
+        when(rxNormClient.getRelatedDrugs("R123")).thenReturn(mockResponse);
+
+        /*
+        * When
+         */
+
+        // Call the method under test
+        Page<Medication> result = medicationService.getRelated("R123", PageRequest.of(0, 10));
+
+        /*
+        * Then
+         */
+
+        // Make assertions
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals("R123", result.getContent().get(0).getRxcui());
+        assertEquals("Ibuprofen", result.getContent().get(0).getName());
     }
 }


### PR DESCRIPTION
- New endpoint in MedicationController allows for searching related medications given an rxcui (returned from 'search' endpoint)
- Involves a new call to RxNorm API, which was added to the OpenFeign client (RxNormClient)
- Added additional mock/unit tests to MedicationServiceTest for RxNorm API service methods
- Updated README.md